### PR TITLE
Add support for timestamps in sec.frac format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# mediajson Changelog
+
+## 1.0.0
+- Initial version, porting json parsing components from nmos-common v.0.6.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # mediajson Changelog
 
+## 1.1.0
+- Add support for "sec.frac"-style timestamps.
+
 ## 1.0.0
 - Initial version, porting json parsing components from nmos-common v.0.6.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # mediajson Changelog
 
 ## 1.1.0
-- Add support for "sec.frac"-style timestamps.
+- Add support for "sec.frac"-style timeranges.
 
 ## 1.0.0
 - Initial version, porting json parsing components from nmos-common v.0.6.0.

--- a/mediajson/__init__.py
+++ b/mediajson/__init__.py
@@ -116,10 +116,10 @@ def decode_value(o):
         if re.match(UUID_REGEX,
                     o):
             return uuid.UUID(o)
-        elif re.match(r'^\d+[:\.]\d+$', o):
-            return Timestamp.from_str(o)
-        elif re.match(r'^(\+|-)\d+[:\.]\d+$', o):
-            return TimeOffset.from_str(o)
+        elif re.match(r'^\d+:\d+$', o):
+            return Timestamp.from_tai_sec_nsec(o)
+        elif re.match(r'^(\+|-)\d+:\d+$', o):
+            return TimeOffset.from_sec_nsec(o)
         elif re.match(r'^(\(|\[)?(\d+[:\.]\d+)?_(\d+[:\.]\d+)?(\)|\])?$', o):
             return TimeRange.from_str(o)
         elif o == "()":

--- a/mediajson/__init__.py
+++ b/mediajson/__init__.py
@@ -116,11 +116,11 @@ def decode_value(o):
         if re.match(UUID_REGEX,
                     o):
             return uuid.UUID(o)
-        elif re.match(r'^\d+:\d+$', o):
-            return Timestamp.from_tai_sec_nsec(o)
-        elif re.match(r'^(\+|-)\d+:\d+$', o):
-            return TimeOffset.from_sec_nsec(o)
-        elif re.match(r'^(\(|\[)?(\d+:\d+)?_(\d+:\d+)?(\)|\])?$', o):
+        elif re.match(r'^\d+[:\.]\d+$', o):
+            return Timestamp.from_str(o)
+        elif re.match(r'^(\+|-)\d+[:\.]\d+$', o):
+            return TimeOffset.from_str(o)
+        elif re.match(r'^(\(|\[)?(\d+[:\.]\d+)?_(\d+[:\.]\d+)?(\)|\])?$', o):
             return TimeRange.from_str(o)
         elif o == "()":
             return TimeRange.never()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import os
 
 # Basic metadata
 name = 'mediajson'
-version = '1.0.0'
+version = '1.1.0'
 description = 'A JSON serialiser and parser for python that supports extensions convenient for our media grain formats'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediajson'
 author = u'James P. Weaver'

--- a/tests/test_mediajson.py
+++ b/tests/test_mediajson.py
@@ -109,6 +109,19 @@ class TestJSON(unittest.TestCase):
 
         self.assertEqual(MEDIAJSON_DATA, decoded)
 
+    def test_decode_mediajson_dotted_times(self):
+        """Insert timeranges formatted in sec.frac form instead of sec:nanosec, check they get decoded"""
+        self.maxDiff = None
+        json_data = json.loads(MEDIAJSON_STRING)
+        json_data["timestamp"] = "417798915.0"
+        json_data["timeranges"][0] = "[417798915.0_417798916.000000999]"
+
+        # Load the ensuing string, check we still get valid timestamps
+        encoded_string = json.dumps(json_data)
+        decoded = mediajson.loads(encoded_string)
+
+        self.assertEqual(MEDIAJSON_DATA, decoded)
+
     def test_load_mediajson(self):
         fp = StringIO(MEDIAJSON_STRING)
 

--- a/tests/test_mediajson.py
+++ b/tests/test_mediajson.py
@@ -113,7 +113,6 @@ class TestJSON(unittest.TestCase):
         """Insert timeranges formatted in sec.frac form instead of sec:nanosec, check they get decoded"""
         self.maxDiff = None
         json_data = json.loads(MEDIAJSON_STRING)
-        json_data["timestamp"] = "417798915.0"
         json_data["timeranges"][0] = "[417798915.0_417798916.000000999]"
 
         # Load the ensuing string, check we still get valid timestamps


### PR DESCRIPTION
The mediatimestamp parsing code accepts "sec.frac" (as opposed to "sec:nanosec") formatted timestamps - this change makes the mediajson decoder accept that format too.

Follows on from #5 