### PR TITLE
Remove install command, build nightly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # mediajson Changelog
 
+## 1.0.1
+- Remove unused install command from tox.ini
+- Add Jenkins build trigger to rebuild master every day.
+- Allow build to run on a wider selection of agents.
+
 ## 1.0.0
 - Initial version, porting json parsing components from nmos-common v.0.6.0.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,9 @@ pipeline {
         booleanParam(name: "FORCE_PYUPLOAD", defaultValue: false, description: "Force Python artifact upload")
         booleanParam(name: "FORCE_DEBUPLOAD", defaultValue: false, description: "Force Debian package upload")
     }
+    triggers {
+        cron(env.BRANCH_NAME == 'master' ? 'H H(0-8) * * *' : '') // Build master some time every morning
+    }
     environment {
         http_proxy = "http://www-cache.rd.bbc.co.uk:8080"
         https_proxy = "http://www-cache.rd.bbc.co.uk:8080"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@
 
 pipeline {
     agent {
-        label "16.04&&ipstudio-deps"
+        label "ubuntu&&apmm-slave"
     }
     options {
         ansiColor('xterm') // Add support for coloured output

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import os
 
 # Basic metadata
 name = 'mediajson'
-version = '1.0.0'
+version = '1.0.1'
 description = 'A JSON serialiser and parser for python that supports extensions convenient for our media grain formats'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediajson'
 author = u'James P. Weaver'

--- a/tox.ini
+++ b/tox.ini
@@ -11,5 +11,3 @@ commands = nose2 --with-coverage --coverage-report=annotate --coverage-report=te
 deps =
     nose2
     mock
-install_command = pip install --process-dependency-links {opts} {packages}
-


### PR DESCRIPTION
Removes the --process-dependency-links flag from tox.ini's install_command, which has been deprecated for some time and now been removed. As a result our install_command is the default, so the entire option has been removed.
Also adds a trigger to build master overnight.