### PR TITLE
Only parse UUIDs that make up the entire string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # mediajson Changelog
 
+## 1.1.1
+- Only attempt to parse UUIDs when they comprise the entire string.
+
 ## 1.1.0
 - Provide support for immutable mediatimestamp and default to mutable.
 - Allow either mutable or immutable when encoding to JSON.

--- a/mediajson/base.py
+++ b/mediajson/base.py
@@ -35,7 +35,7 @@ import mediatimestamp.mutable as mutable
 import mediatimestamp.immutable as immutable
 
 
-UUID_REGEX = re.compile(r'[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}')
+UUID_REGEX = re.compile(r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')
 
 
 def dump(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import os
 
 # Basic metadata
 name = 'mediajson'
-version = '1.1.0'
+version = '1.1.1'
 description = 'A JSON serialiser and parser for python that supports extensions convenient for our media grain formats'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediajson'
 author = u'James P. Weaver'


### PR DESCRIPTION
Add start and end checks to the UUID detection regex, to avoid things like folder paths that contain a UUID from being parsed as one.

This fixes a problem where a JSON document containing a file path like `1a48d4ec-6201-4c64-9408-1a484c1616b4/output.mov` throws back:

```
Traceback (most recent call last):
  File "/vagrant/src/packager/tests/test_supervisor.py", line 32, in setUpClass
    cls.msg_data = mediajson.load(fp)  # needs to be mediajson for comparisons to work
<snip more traceback>
  File "/vagrant/src/packager/.tox/py3/lib/python3.6/site-packages/mediajson/base.py", line 107, in _base_decode_value
    res[key] = _base_decode_value(o[key], timestamp_cls, timeoffset_cls, timerange_cls)
  File "/vagrant/src/packager/.tox/py3/lib/python3.6/site-packages/mediajson/base.py", line 114, in _base_decode_value
    return uuid.UUID(o)
  File "/usr/lib/python3.6/uuid.py", line 140, in __init__
    raise ValueError('badly formed hexadecimal UUID string')
ValueError: badly formed hexadecimal UUID string
```

Note this is tracked by Cloud-fit [Pivotal#170265355](https://www.pivotaltracker.com/story/show/170265355)

I'm assuming (hoping!) nobody is depending on this behaviour!