### PR TITLE
Allow float in JSON serialisable typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # mediajson Changelog
 
+# 2.0.1
+- Add `float` to JSON serialisable typing.
+
 # 2.0.0
 - Dropped support for versions of python prior to 3.6
 - Dropped all support for mutable timestamps

--- a/mediajson/typing.py
+++ b/mediajson/typing.py
@@ -42,7 +42,7 @@ RationalTypes = Union[str, float, Decimal, Rational]
 #
 #  Hopefully at some point in the future proper recursive type definitions will be supported
 #  Until that time we simply assume none of our json structures are all that deep
-_MediaJSONSerialisable_value = Union[str, int, UUID, TimeOffset, TimeRange, Fraction]
+_MediaJSONSerialisable_value = Union[str, int, float, UUID, TimeOffset, TimeRange, Fraction]
 # This means that type checking stops at the fourth level
 _MediaJSONSerialisable0 = Union[_MediaJSONSerialisable_value, Sequence[Any], Mapping[str, Any]]
 _MediaJSONSerialisable1 = Union[_MediaJSONSerialisable_value, Sequence[_MediaJSONSerialisable0],
@@ -57,7 +57,7 @@ MediaJSONSerialisable = _MediaJSONSerialisable4
 
 
 # This mechanism does the same for the standard JSON serialisability
-_JSONSerialisable_value = Union[str, int]
+_JSONSerialisable_value = Union[str, int, float]
 # This means that type checking stops at the fourth level
 _JSONSerialisable0 = Union[_JSONSerialisable_value, Sequence[Any], Mapping[str, Any]]
 _JSONSerialisable1 = Union[_JSONSerialisable_value, Sequence[_JSONSerialisable0],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 
 # Basic metadata
 name = 'mediajson'
-version = '2.0.0'
+version = '2.0.1'
 description = 'A JSON serialiser and parser for python that supports extensions convenient for our media grain formats'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediajson'
 author = u'James P. Weaver'


### PR DESCRIPTION
The Bobcat transcode code includes support for 'float' parameter values.

The 'int' type was not removed as PEP 484, which allows 'float' to be
used to include 'int', has a provisional status and could still
be rejected.

Pivotal: https://www.pivotaltracker.com/story/show/170947782