### PR TITLE
Filter out encoding parameter in NMOSJSONDecoder init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # mediajson Changelog
 
+# 2.0.3
+- Filter out legacy `encoding` parameter in `NMOSJSONDecoder.__init__` to workaround simplejson adding it.
+
 # 2.0.2
 - Add support for encoding `SupportsMediaTimeOffset`, `SupportsMediaTimestamp` and `SupportsMediaTimeRange`
 

--- a/mediajson/decode.py
+++ b/mediajson/decode.py
@@ -87,6 +87,16 @@ def decode_value(o: JSONSerialisable) -> MediaJSONSerialisable:
 
 
 class NMOSJSONDecoder(JSONDecoder):
+    def __init__(self, **kwargs):
+        # Filter out the 'encoding' parameter as a simple workaround for simplejson adding it.
+        # The parameter is no longer supported in python 3.
+        py3_kwargs = {
+            key: value
+            for (key, value) in kwargs.items()
+            if key != "encoding"
+        }
+        super().__init__(**py3_kwargs)
+
     def raw_decode(self, s: str, *args, **kwargs) -> Tuple[MediaJSONSerialisable, int]:
         value: JSONSerialisable
         (value, offset) = super(NMOSJSONDecoder, self).raw_decode(s,

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 
 # Basic metadata
 name = 'mediajson'
-version = '2.0.2.post1'
+version = '2.0.3'
 description = 'A JSON serialiser and parser for python that supports extensions convenient for our media grain formats'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediajson'
 author = u'James P. Weaver'


### PR DESCRIPTION
Using mediajson.JSONDecoder to decode json as `response.json(cls=NMOSJSONDecoder)` resulted in an error if simplejson is installed. This PR adds a workaround to mediajson to filter out the `encoding` parameter that simplejson passes to the NMOSJSONDecoder / JSONDecoder.

The requests library imports the simplejson library if available and otherwise imports json. The requests response's `json()` method calls the simplejson / json library `loads()` method, https://github.com/psf/requests/blob/master/requests/models.py#L905.

The simplejson `loads()` method initialises the JSONDecoder with the `encoding` parameter, https://github.com/simplejson/simplejson/blob/master/simplejson/__init__.py#L542. That parameter is no longer present in python 3 and the result is an exception.