### PR TITLE
Move to Python 3.10, switch default branch to main, tidy up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # mediajson Changelog
 
+# 2.1.0
+- Drop support for Python <= 3.10 (3.6 upwards should still work, but are no longer explictly supported or built for)
+
 # 2.0.3
 - Filter out legacy `encoding` parameter in `NMOSJSONDecoder.__init__` to workaround simplejson adding it.
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,11 +6,11 @@
  - Run Python 3 unit tests in tox
  - Build Debian packages for supported Ubuntu versions
 
- If these steps succeed and the master branch is being built, wheels and debs are uploaded to Artifactory and the
+ If these steps succeed and the main branch is being built, wheels and debs are uploaded to Artifactory and the
  R&D Debian mirrors.
 
  Optionally you can set FORCE_PYUPLOAD to force upload to Artifactory, and FORCE_DEBUPLOAD to force Debian package
- upload on non-master branches.
+ upload on non-main branches.
 */
 
 pipeline {
@@ -26,7 +26,7 @@ pipeline {
         booleanParam(name: "FORCE_DEBUPLOAD", defaultValue: false, description: "Force Debian package upload")
     }
     triggers {
-        cron(env.BRANCH_NAME == 'master' ? 'H H(0-8) * * *' : '') // Build master some time every morning
+        cron(env.BRANCH_NAME == 'main' ? 'H H(0-8) * * *' : '') // Build main some time every morning
     }
     environment {
         http_proxy = "http://www-cache.rd.bbc.co.uk:8080"
@@ -87,19 +87,19 @@ pipeline {
         stage ("Python Unit Tests") {
             steps {
                 script {
-                    env.py3_result = "FAILURE"
+                    env.unittest_result = "FAILURE"
                 }
-                bbcGithubNotify(context: "tests/py3", status: "PENDING")
+                bbcGithubNotify(context: "tests/unit", status: "PENDING")
                 withBBCRDPythonArtifactory {
                    sh 'make test'
                 }
                 script {
-                    env.py3_result = "SUCCESS" // This will only run if the sh above succeeded
+                    env.unittest_result = "SUCCESS" // This will only run if the sh above succeeded
                 }
             }
             post {
                 always {
-                    bbcGithubNotify(context: "tests/py3", status: env.py3_result)
+                    bbcGithubNotify(context: "tests/unit", status: env.unittest_result)
                 }
             }
         }
@@ -132,7 +132,7 @@ pipeline {
                 bbcGithubNotify(context: "deb/packageBuild", status: "PENDING")
                 // Build for all supported platforms and extract results into workspace
                 bbcParallelPbuild(stashname: "deb_dist",
-                                    dists: bbcGetSupportedUbuntuVersions(exclude: ["xenial"]),
+                                    dists: bbcGetSupportedUbuntuVersions(),
                                     arch: "amd64")
             }
             post {
@@ -152,7 +152,7 @@ pipeline {
                     expression { return params.FORCE_PYUPLOAD }
                     expression { return params.FORCE_DEBUPLOAD }
                     expression {
-                        bbcShouldUploadArtifacts(branches: ["master", "dev"])
+                        bbcShouldUploadArtifacts(branches: ["main", "dev"])
                     }
                 }
             }
@@ -162,7 +162,7 @@ pipeline {
                         anyOf {
                             expression { return params.FORCE_PYUPLOAD }
                             expression {
-                                bbcShouldUploadArtifacts(branches: ["master"])
+                                bbcShouldUploadArtifacts(branches: ["main"])
                             }
                         }
                     }
@@ -218,7 +218,7 @@ pipeline {
                         anyOf {
                             expression { return params.FORCE_DEBUPLOAD }
                             expression {
-                                bbcShouldUploadArtifacts(branches: ["master"])
+                                bbcShouldUploadArtifacts(branches: ["main"])
                             }
                         }
                     }
@@ -228,7 +228,7 @@ pipeline {
                         }
                         bbcGithubNotify(context: "deb/upload", status: "PENDING")
                         script {
-                            for (def dist in bbcGetSupportedUbuntuVersions()) {
+                            for (def dist in bbcGetSupportedUbuntuVersions(exclude: ["xenial"])) {
                                 bbcDebUpload(sourceFiles: "_result/${dist}-amd64/*",
                                                 removePrefix: "_result/${dist}-amd64",
                                                 dist: "${dist}",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,10 +40,9 @@ pipeline {
                 sh 'rm -rf /tmp/$(basename ${WORKSPACE})/'
             }
         }
-        stage("Ensure pyenv has python3.6.8") {
+        stage("Prepare for build") {
             steps {
-                sh "pyenv install -s 3.6.8"
-                sh "pyenv local 3.6.8"
+                bbcStagePyenvEnsureVersion("3.10")
             }
         }
         stage ("Linting Check") {
@@ -172,8 +171,8 @@ pipeline {
                         }
                         bbcGithubNotify(context: "pypi/upload", status: "PENDING")
                         sh 'rm -rf dist/*'
-                        bbcMakeGlobalWheel("py36")
-                        bbcTwineUpload(toxenv: "py36", pypi: true)
+                        bbcMakeGlobalWheel("py310")
+                        bbcTwineUpload(toxenv: "py310", pypi: true)
                         script {
                             env.pypiUpload_result = "SUCCESS" // This will only run if the steps above succeeded
                         }
@@ -200,9 +199,9 @@ pipeline {
                         bbcGithubNotify(context: "artifactory/upload", status: "PENDING")
                         sh 'rm -rf dist/*'
                         withBBCRDPythonArtifactory {
-                            bbcMakeGlobalWheel("py36")
+                            bbcMakeGlobalWheel("py310")
                         }
-                        bbcTwineUpload(toxenv: "py36", pypi: false)
+                        bbcTwineUpload(toxenv: "py310", pypi: false)
                         script {
                             env.artifactoryUpload_result = "SUCCESS" // This will only run if the steps above succeeded
                         }

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ RPMBUILDDIRS=$(patsubst %, $(RPM_PREFIX)/%, $(RPMDIRS))
 
 TOX_WORK_DIR?=$(topbuilddir)
 TOXDIR=$(TOX_WORK_DIR)/$(MODNAME)/.tox/
-TOXENV?=py36
+TOXENV?=py310
 TOX_ACTIVATE=$(TOXDIR)/$(TOXENV)/bin/activate
 
 all:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PROJECT=$(shell python $(topdir)/setup.py --name)
 VERSION=$(shell python $(topdir)/setup.py --version)
 MODNAME=$(PROJECT)
 
-# The rules for names and versions in python, rpm, and deb are different
+# The rules for names and versions in python and deb are different
 # and not entirely compatible. As such py2dsc will automatically convert
 # your package name into a suitable deb name and version number, and this
 # code replicates that.
@@ -18,12 +18,6 @@ DEBVERSION=$(shell echo $(VERSION) | sed 's/\.dev/~dev/')
 
 DEBIANDIR=$(topbuilddir)/deb_dist/$(DEBNAME)-$(DEBVERSION)/debian
 DEBIANOVERRIDES=$(patsubst $(topdir)/debian/%,$(DEBIANDIR)/%,$(wildcard $(topdir)/debian/*))
-
-RPM_PARAMS?=
-RPM_PREFIX?=$(topdir)/build/rpm
-
-RPMDIRS=BUILD BUILDROOT RPMS SOURCES SPECS SRPMS
-RPMBUILDDIRS=$(patsubst %, $(RPM_PREFIX)/%, $(RPMDIRS))
 
 TOX_WORK_DIR?=$(topbuilddir)
 TOXDIR=$(TOX_WORK_DIR)/$(MODNAME)/.tox/
@@ -38,10 +32,8 @@ all:
 	@echo "make test    - Test using tox and nose2"
 	@echo "make deb     - Create deb package"
 	@echo "make dsc     - Create debian source package"
-	@echo "make rpm     - Create rpm package"
 	@echo "make wheel   - Create whl package"
 	@echo "make egg     - Create egg package"
-	@echo "make rpm_dirs - Create directories for rpm building"
 
 $(topbuilddir)/dist:
 	mkdir -p $@
@@ -91,35 +83,10 @@ deb: source deb_dist $(DEBIANOVERRIDES)
 	cd $(DEBIANDIR)/..;debuild -uc -us
 	cp $(topbuilddir)/deb_dist/python*$(DEBNAME)_$(DEBVERSION)-1*.deb $(topbuilddir)/dist
 
-# START OF RPM SPEC RULES
-# If you have your own rpm spec file to use you'll need to disable these rules
-$(RPM_PREFIX)/$(MODNAME).spec: rpm_spec
-
-rpm_spec: $(topdir)/setup.py
-	$(PYTHON3) $(topdir)/setup.py bdist_rpm $(RPM_PARAMS) --spec-only --dist-dir=$(RPM_PREFIX)
-# END OF RPM SPEC RULES
-
-$(RPMBUILDDIRS):
-	mkdir -p $@
-
-$(RPM_PREFIX)/SPECS/$(MODNAME).spec: $(RPM_PREFIX)/$(MODNAME).spec $(RPM_PREFIX)/SPECS
-	rm -rf $@
-	cp -f $< $@
-
-$(RPM_PREFIX)/SOURCES/$(MODNAME)-$(VERSION).tar.gz: $(topbuilddir)/dist/$(MODNAME)-$(VERSION).tar.gz $(RPM_PREFIX)/SOURCES
-	rm -rf $@
-	cp -f $< $@
-
-rpm_dirs: $(RPMBUILDDIRS) $(RPM_PREFIX)/SPECS/$(MODNAME).spec $(RPM_PREFIX)/SOURCES/$(MODNAME)-$(VERSION).tar.gz
-
-rpm: $(RPM_PREFIX)/SPECS/$(MODNAME).spec $(RPM_PREFIX)/SOURCES/$(MODNAME)-$(VERSION).tar.gz $(RPMBUILDDIRS)
-	rpmbuild -ba --define '_topdir $(RPM_PREFIX)' --clean $<
-	cp $(RPM_PREFIX)/RPMS/*/*.rpm $(topbuilddir)/dist
-
 wheel:
 	$(PYTHON) $(topdir)/setup.py bdist_wheel
 
 egg:
 	$(PYTHON) $(topdir)/setup.py bdist_egg
 
-.PHONY: test clean install source deb dsc rpm wheel egg all rpm_dirs rpm_spec docs
+.PHONY: test clean install source deb dsc wheel egg all docs

--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ Please ensure you have run the test suite before submitting a Pull Request, and 
 
 ## Authors
 
-* James Weaver (james.barrett@bbc.co.uk)
+* James Weaver
 * Philip deNier (philip.denier@bbc.co.uk)
-* Sam Nicholson (sam.nicholson@bbc.co.uk)
+* Sam Mesterton-Gibbons (sam.mesterton-gibbons@bbc.co.uk)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -60,14 +60,11 @@ $ make test
 ```
 ### Packaging
 
-Debian and RPM packages can be built using:
+Debian packages can be built using:
 
 ```bash
 # Debian packaging
 $ make deb
-
-# RPM packageing
-$ make rpm
 ```
 
 ### Continuous Integration

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ understanding a wider range of python types including the `mediatimestamps.times
 
 ### Requirements
 
-* A working Python 3.6+ installation
+* A working Python 3.10+ installation
 * The tool [tox](https://tox.readthedocs.io/en/latest/) is needed to run the unittests, but not required to use the library.
 
 ### Steps

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_rpm]
-build_requires=python34,python34-setuptools

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import os
 
 # Basic metadata
 name = 'mediajson'
-version = '2.0.3'
+version = '2.1.0'
 description = 'A JSON serialiser and parser for python that supports extensions convenient for our media grain formats'
 url = 'https://github.com/bbc/rd-apmm-python-lib-mediajson'
 author = u'James P. Weaver'

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ packages_required = [
 deps_required = []
 
 setup(name=name,
-      python_requires='>=3.6.0',
+      python_requires='>=3.10.0',
       version=version,
       description=description,
       url=url,

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist = py310
 toxworkdir = {env:TOX_WORK_DIR:{toxinidir}}/mediajson/.tox
 
 [testenv]
-commands = python -m unittest discover -s tests
+commands = python -m unittest -v
 deps =
     flake8
     mypy

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py36
+envlist = py310
 toxworkdir = {env:TOX_WORK_DIR:{toxinidir}}/mediajson/.tox
 
 [testenv]


### PR DESCRIPTION
- Moves to Python 3.10 as minimum supported version
- Changes default branch to main in CI
- Removes some unused tooling
- Makes unittests a package in common with our other repos
- Updates list of names and email addresses

https://www.pivotaltracker.com/story/show/180266749

