### PR TITLE
Remove un-needed gitignore line from makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,4 +166,3 @@ _version.py
 
 # Extra gitignore lines from Makefile
 Dockerfile.multi
-Dockerfile.multi

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
 USE_VERSION_FILE:=TRUE
 
-# Needed here due to gitignore being generated in standalone.mk but Dockerfile.multi being added in docker.mk
-EXTRA_GITIGNORE_LINES+=Dockerfile.multi
-
 include ./static-commontooling/make/lib_static_commontooling.mk
 include ./static-commontooling/make/standalone.mk
 include ./static-commontooling/make/pythonic.mk


### PR DESCRIPTION
# Details
Minor fix removing un-needed gitignore line from makefile. Spotted in other PRs in this set after this merged. Feel free to merge if accepted.

# Pivotal Story
Story URL:

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [ ] Added bbc/rd-apmm-cloudfit team as a reviewer
- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
