### PR TITLE
Timestamp and range updates

### DIFF
--- a/mediajson/decode.py
+++ b/mediajson/decode.py
@@ -30,7 +30,7 @@ import re
 from typing import Tuple
 from .typing import MediaJSONSerialisable, JSONSerialisable
 
-from mediatimestamp.immutable import Timestamp, TimeOffset, TimeRange
+from mediatimestamp.immutable import Timestamp, TimeRange
 
 
 __all__ = ["load", "loads",
@@ -75,10 +75,8 @@ def decode_value(o: JSONSerialisable) -> MediaJSONSerialisable:
         if re.match(UUID_REGEX,
                     o):
             return uuid.UUID(o)
-        elif re.match(r'^\d+:\d+$', o):
-            return Timestamp.from_tai_sec_nsec(o)
-        elif re.match(r'^(\+|-)\d+:\d+$', o):
-            return TimeOffset.from_sec_nsec(o)
+        elif re.match(r'^(\+|-)?\d+:\d+$', o):
+            return Timestamp.from_sec_nsec(o)
         elif re.match(r'^(\(|\[)?(\d+:\d+)?_(\d+:\d+)?(\)|\])?$', o):
             return TimeRange.from_str(o)
         elif o == "()":

--- a/mediajson/decode.py
+++ b/mediajson/decode.py
@@ -75,7 +75,7 @@ def decode_value(o: JSONSerialisable) -> MediaJSONSerialisable:
         if re.match(UUID_REGEX,
                     o):
             return uuid.UUID(o)
-        elif re.match(r'^(\+|-)?\d+:\d+$', o):
+        elif re.match(r'^-?\d+:\d+$', o):
             return Timestamp.from_sec_nsec(o)
         elif re.match(r'^(\(|\[)?(\d+:\d+)?_(\d+:\d+)?(\)|\])?$', o):
             return TimeRange.from_str(o)

--- a/mediajson/decode.py
+++ b/mediajson/decode.py
@@ -77,7 +77,7 @@ def decode_value(o: JSONSerialisable) -> MediaJSONSerialisable:
             return uuid.UUID(o)
         elif re.match(r'^-?\d+:\d+$', o):
             return Timestamp.from_sec_nsec(o)
-        elif re.match(r'^(\(|\[)?(\d+:\d+)?_(\d+:\d+)?(\)|\])?$', o):
+        elif re.match(r'^(\(|\[)?(-?\d+:\d+)?_(-?\d+:\d+)?(\)|\])?$', o):
             return TimeRange.from_str(o)
         elif o == "()":
             return TimeRange.never()

--- a/mediajson/encode.py
+++ b/mediajson/encode.py
@@ -31,7 +31,6 @@ from .typing import MediaJSONSerialisable, JSONSerialisable
 
 from mediatimestamp.immutable import (
     Timestamp, SupportsMediaTimestamp, mediatimestamp,
-    TimeOffset, SupportsMediaTimeOffset, mediatimeoffset,
     TimeRange, SupportsMediaTimeRange, mediatimerange)
 
 
@@ -75,8 +74,6 @@ def encode_value(o: MediaJSONSerialisable,
     elif isinstance(o, uuid.UUID):
         return str(o)
     elif isinstance(o, Timestamp):
-        return o.to_tai_sec_nsec()
-    elif isinstance(o, TimeOffset):
         return o.to_sec_nsec()
     elif isinstance(o, TimeRange):
         return o.to_sec_nsec_range()
@@ -85,8 +82,6 @@ def encode_value(o: MediaJSONSerialisable,
                 "denominator": o.denominator}
     elif isinstance(o, SupportsMediaTimestamp):
         return mediatimestamp(o).to_tai_sec_nsec()
-    elif isinstance(o, SupportsMediaTimeOffset):
-        return mediatimeoffset(o).to_sec_nsec()
     elif isinstance(o, SupportsMediaTimeRange):
         return mediatimerange(o).to_sec_nsec_range()
     else:

--- a/mediajson/typing.py
+++ b/mediajson/typing.py
@@ -25,10 +25,7 @@ from decimal import Decimal
 from numbers import Rational
 from fractions import Fraction
 from uuid import UUID
-from mediatimestamp.immutable import (
-    SupportsMediaTimeOffset,
-    SupportsMediaTimestamp,
-    SupportsMediaTimeRange)
+from mediatimestamp.immutable import SupportsMediaTimestamp, SupportsMediaTimeRange
 
 
 __all__ = ["RationalTypes",
@@ -50,7 +47,6 @@ _MediaJSONSerialisable_value = Union[
     int,
     float,
     UUID,
-    SupportsMediaTimeOffset,
     SupportsMediaTimestamp,
     SupportsMediaTimeRange,
     Fraction]

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ packages = {
 
 # This is where you list packages which are required
 packages_required = [
-    "mediatimestamp >= 2.1.0",
+    "mediatimestamp >= 4.0.0",
     "typing_extensions"
 ]
 

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -54,15 +54,20 @@ MEDIAJSON_DATA = {
                    TimeRange.from_start(Timestamp(417798915, 0), TimeRange.INCLUSIVE),
                    TimeRange.from_start(Timestamp(417798915, 0), TimeRange.EXCLUSIVE),
                    TimeRange.from_end(Timestamp(417798915, 0), TimeRange.INCLUSIVE),
-                   TimeRange.from_end(Timestamp(417798915, 0), TimeRange.EXCLUSIVE)]
+                   TimeRange.from_end(Timestamp(417798915, 0), TimeRange.EXCLUSIVE),
+                   TimeRange(Timestamp(417798916, 999, -1), Timestamp(417798915, 0, -1), TimeRange.INCLUSIVE),
+                   TimeRange(Timestamp(417798916, 999, -1), Timestamp(417798915, 0), TimeRange.INCLUSIVE),
+                   TimeRange.from_start(Timestamp(417798916, 999, -1), TimeRange.INCLUSIVE),
+                   TimeRange.from_end(Timestamp(417798916, 999, -1), TimeRange.INCLUSIVE)]
 }
 
 MEDIAJSON_STRING = '{"foo": "bar", "baz": ["boop", "beep"], "boggle": {"cat": "\\u732b", "kitten": "\\u5b50\\u732b"}, '\
     '"numeric": 25, "boolean": true, "decimal": 0.44, "uuid": "b8b4a34f-3293-11e8-89c0-acde48001122", '\
     '"rational": {"numerator": 30000, "denominator": 1001},'\
     '"timestamps": ["417798915:0", "-417798915:0"],'\
-    '"timeranges": ["[417798915:0_417798916:999]", "(417798915:0_417798916:999)", "[417798915:0_417798916:999)", '\
-    '"(417798915:0_417798916:999]", "()", "_", "[417798915:0_", "(417798915:0_", "_417798915:0]", "_417798915:0)"]}'
+    '"timeranges": ["[417798915:0_417798916:999]", "(417798915:0_417798916:999)", "[417798915:0_417798916:999)",'\
+    '"(417798915:0_417798916:999]", "()", "_", "[417798915:0_", "(417798915:0_", "_417798915:0]", "_417798915:0)",'\
+    '"[-417798916:999_-417798915:0]", "[-417798916:999_417798915:0]", "[-417798916:999_", "_-417798916:999]"]}'
 
 
 class TestJSONDecode(unittest.TestCase):

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -44,7 +44,7 @@ MEDIAJSON_DATA = {
     "decimal": 0.44,
     "uuid": UUID("b8b4a34f-3293-11e8-89c0-acde48001122"),
     "rational": Fraction(30000, 1001),
-    "timestamp": Timestamp.from_sec_nsec("417798915:0"),
+    "timestamps": [Timestamp.from_sec_nsec("417798915:0"), Timestamp.from_sec_nsec("-417798915:0")],
     "timeranges": [TimeRange(Timestamp(417798915, 0), Timestamp(417798916, 999), TimeRange.INCLUSIVE),
                    TimeRange(Timestamp(417798915, 0), Timestamp(417798916, 999), TimeRange.EXCLUSIVE),
                    TimeRange(Timestamp(417798915, 0), Timestamp(417798916, 999), TimeRange.INCLUDE_START),
@@ -59,7 +59,8 @@ MEDIAJSON_DATA = {
 
 MEDIAJSON_STRING = '{"foo": "bar", "baz": ["boop", "beep"], "boggle": {"cat": "\\u732b", "kitten": "\\u5b50\\u732b"}, '\
     '"numeric": 25, "boolean": true, "decimal": 0.44, "uuid": "b8b4a34f-3293-11e8-89c0-acde48001122", '\
-    '"rational": {"numerator": 30000, "denominator": 1001}, "timestamp": "417798915:0",'\
+    '"rational": {"numerator": 30000, "denominator": 1001},'\
+    '"timestamps": ["417798915:0", "-417798915:0"],'\
     '"timeranges": ["[417798915:0_417798916:999]", "(417798915:0_417798916:999)", "[417798915:0_417798916:999)", '\
     '"(417798915:0_417798916:999]", "()", "_", "[417798915:0_", "(417798915:0_", "_417798915:0]", "_417798915:0)"]}'
 

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -45,7 +45,7 @@ MEDIAJSON_DATA = {
     "decimal": 0.44,
     "uuid": UUID("b8b4a34f-3293-11e8-89c0-acde48001122"),
     "rational": Fraction(30000, 1001),
-    "timestamp": Timestamp.from_sec_nsec("417798915:0"),
+    "timestamps": [Timestamp.from_sec_nsec("417798915:0"), Timestamp.from_sec_nsec("-417798915:0")],
     "timeranges": [TimeRange(Timestamp(417798915, 0), Timestamp(417798916, 999), TimeRange.INCLUSIVE),
                    TimeRange(Timestamp(417798915, 0), Timestamp(417798916, 999), TimeRange.EXCLUSIVE),
                    TimeRange(Timestamp(417798915, 0), Timestamp(417798916, 999), TimeRange.INCLUDE_START),
@@ -60,7 +60,8 @@ MEDIAJSON_DATA = {
 
 MEDIAJSON_STRING = '{"foo": "bar", "baz": ["boop", "beep"], "boggle": {"cat": "\\u732b", "kitten": "\\u5b50\\u732b"}, '\
     '"numeric": 25, "boolean": true, "decimal": 0.44, "uuid": "b8b4a34f-3293-11e8-89c0-acde48001122", '\
-    '"rational": {"numerator": 30000, "denominator": 1001}, "timestamp": "417798915:0",'\
+    '"rational": {"numerator": 30000, "denominator": 1001},'\
+    '"timestamps": ["417798915:0", "-417798915:0"],'\
     '"timeranges": ["[417798915:0_417798916:999]", "(417798915:0_417798916:999)", "[417798915:0_417798916:999)", '\
     '"(417798915:0_417798916:999]", "()", "_", "[417798915:0_", "(417798915:0_", "_417798915:0]", "_417798915:0)"]}'
 

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -55,15 +55,20 @@ MEDIAJSON_DATA = {
                    TimeRange.from_start(Timestamp(417798915, 0), TimeRange.INCLUSIVE),
                    TimeRange.from_start(Timestamp(417798915, 0), TimeRange.EXCLUSIVE),
                    TimeRange.from_end(Timestamp(417798915, 0), TimeRange.INCLUSIVE),
-                   TimeRange.from_end(Timestamp(417798915, 0), TimeRange.EXCLUSIVE)]
+                   TimeRange.from_end(Timestamp(417798915, 0), TimeRange.EXCLUSIVE),
+                   TimeRange(Timestamp(417798916, 999, -1), Timestamp(417798915, 0, -1), TimeRange.INCLUSIVE),
+                   TimeRange(Timestamp(417798916, 999, -1), Timestamp(417798915, 0), TimeRange.INCLUSIVE),
+                   TimeRange.from_start(Timestamp(417798916, 999, -1), TimeRange.INCLUSIVE),
+                   TimeRange.from_end(Timestamp(417798916, 999, -1), TimeRange.INCLUSIVE)]
 }
 
 MEDIAJSON_STRING = '{"foo": "bar", "baz": ["boop", "beep"], "boggle": {"cat": "\\u732b", "kitten": "\\u5b50\\u732b"}, '\
     '"numeric": 25, "boolean": true, "decimal": 0.44, "uuid": "b8b4a34f-3293-11e8-89c0-acde48001122", '\
     '"rational": {"numerator": 30000, "denominator": 1001},'\
     '"timestamps": ["417798915:0", "-417798915:0"],'\
-    '"timeranges": ["[417798915:0_417798916:999]", "(417798915:0_417798916:999)", "[417798915:0_417798916:999)", '\
-    '"(417798915:0_417798916:999]", "()", "_", "[417798915:0_", "(417798915:0_", "_417798915:0]", "_417798915:0)"]}'
+    '"timeranges": ["[417798915:0_417798916:999]", "(417798915:0_417798916:999)", "[417798915:0_417798916:999)",'\
+    '"(417798915:0_417798916:999]", "()", "_", "[417798915:0_", "(417798915:0_", "_417798915:0]", "_417798915:0)",'\
+    '"[-417798916:999_-417798915:0]", "[-417798916:999_417798915:0]", "[-417798916:999_", "_-417798916:999]"]}'
 
 
 class TestJSONEncode(unittest.TestCase):


### PR DESCRIPTION
# Details
This PR removes deprecated TimeOffset and related typing. It adds support for negative Timestamps and TimeRanges.The option to use a '+' in front of a timestamp has been removed as it is not common practice to do that and adds unnecessary additional complications to the Cloudfit codebase.

# Pivotal Story
Story URL: https://www.pivotaltracker.com/story/show/182547184

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [x] Added bbc/rd-apmm-cloudfit team as a reviewer
- [x] PR completes task/fixes bug
- [x] Tests exercise code appropriately
- [x] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [x] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
