### PR TITLE
Regenerate static files

### DIFF
--- a/static-commontooling/make/pythonic.mk
+++ b/static-commontooling/make/pythonic.mk
@@ -60,6 +60,7 @@ SDIST_FILE?=$(topbuilddir)/dist/$(MODNAME)-$(VERSION).tar.gz
 EXTRA_DOCKER_BUILD_ARGS += --secret id=pipconf,src=$(PIP_CONFIG_FILE)
 
 wheel: $(WHEEL_FILE)
+wheels: wheel
 source: source-pythonic
 source-pythonic: $(SDIST_FILE)
 


### PR DESCRIPTION
# Details
Regenerate the static Makefiles to pick up a change to the wheel build targets

# Pivotal Story
Story URL: Part of https://www.pivotaltracker.com/story/show/186363984

# Related PRs
Arises from https://github.com/bbc/rd-cloudfit-commontooling/pull/272

# Links to external test runs/working deployment
N/A

# Submitter PR Checks
_(tick as appropriate)_

- [X] Added bbc/rd-apmm-cloudfit team as a reviewer
- [X] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Repo maintainer is notified that a release is required
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
