### PR TITLE
Accept fraction with just a numerator

### DIFF
--- a/mediajson/decode.py
+++ b/mediajson/decode.py
@@ -64,6 +64,8 @@ def decode_value(o: JSONSerialisable) -> MediaJSONSerialisable:
     if isinstance(o, dict):
         if len(o.keys()) == 2 and "numerator" in o and "denominator" in o:
             return Fraction(o['numerator'], o['denominator'])
+        elif len(o.keys()) == 1 and "numerator" in o:
+            return Fraction(o['numerator'], 1)
         else:
             res = {}
             for key in o:

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -43,7 +43,7 @@ MEDIAJSON_DATA = {
     "boolean": True,
     "decimal": 0.44,
     "uuid": UUID("b8b4a34f-3293-11e8-89c0-acde48001122"),
-    "rational": Fraction(30000, 1001),
+    "rationals": [Fraction(30000, 1001), Fraction(50, 1)],
     "timestamps": [Timestamp.from_sec_nsec("417798915:0"), Timestamp.from_sec_nsec("-417798915:0")],
     "timeranges": [TimeRange(Timestamp(417798915, 0), Timestamp(417798916, 999), TimeRange.INCLUSIVE),
                    TimeRange(Timestamp(417798915, 0), Timestamp(417798916, 999), TimeRange.EXCLUSIVE),
@@ -63,7 +63,7 @@ MEDIAJSON_DATA = {
 
 MEDIAJSON_STRING = '{"foo": "bar", "baz": ["boop", "beep"], "boggle": {"cat": "\\u732b", "kitten": "\\u5b50\\u732b"}, '\
     '"numeric": 25, "boolean": true, "decimal": 0.44, "uuid": "b8b4a34f-3293-11e8-89c0-acde48001122", '\
-    '"rational": {"numerator": 30000, "denominator": 1001},'\
+    '"rationals": [{"numerator": 30000, "denominator": 1001}, {"numerator": 50}], '\
     '"timestamps": ["417798915:0", "-417798915:0"],'\
     '"timeranges": ["[417798915:0_417798916:999]", "(417798915:0_417798916:999)", "[417798915:0_417798916:999)",'\
     '"(417798915:0_417798916:999]", "()", "_", "[417798915:0_", "(417798915:0_", "_417798915:0]", "_417798915:0)",'\


### PR DESCRIPTION
# Details
This PR supports reading fractions with an optional denominator (which defaults to 1). It does not change writing fracions to avoid breaking cases where the denominator is not optional in the JSON schema.

The TAMS for example has `frame_rate` [specified](https://github.com/bbc/tams/blob/main/api/schemas/flow-video.json#L35) with an optional `denominator`.

# Pivotal Story
Story URL: Part of https://www.pivotaltracker.com/story/show/187542840

# Related PRs
_Where appropriate. Indicate order to be merged._

# Links to external test runs/working deployment
_Where appropriate, if separate to default CI run_

# Submitter PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] New features and API breaks are flagged in commit messages using magic strings
- [ ] Documentation updated (README, Confluence, Docstrings, API spec, Engineering Guide, etc.)
- [ ] Downstream repos have been checked for potential breaks & fixed as needed
- [ ] APIs/UIs/CLIs updated as required
- [ ] PR added to Pivotal story
- [ ] Follow-up stories added to Pivotal
- [ ] Any temporary code/configuration removed (e.g. test deployment environment, temporary commontooling branch)
- [ ] Any pins against pre-releases have been removed

# Reviewer PR Checks
_(tick as appropriate)_

- [ ] PR completes task/fixes bug
- [ ] Tests exercise code appropriately
- [ ] Design makes sense, and fits with our current code base
- [ ] Code is easy to follow
- [ ] PR size is sensible
- [ ] Commit history is sensible and tidy

# Info on Cloudfit PRs
- The checks above are guidelines. They don't all have to be ticked, but they should all have been considered.
- For more details on how to asses PRs, see: https://github.com/bbc/rd-apmm-docs-ways-of-working/blob/master/workflow/PRChecklist.md
